### PR TITLE
fix: pin cross 0.2.4 for aarch64 release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy, rustfmt
       - name: Format
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy, rustfmt
       - name: Clippy
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy, rustfmt
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.89.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install cross
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --version 0.2.4 --locked
 
       - name: Build binary (cross)
         if: matrix.cross

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88.0-bookworm AS chef
+FROM rust:1.89.0-bookworm AS chef
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \

--- a/server/rust-toolchain.toml
+++ b/server/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"


### PR DESCRIPTION
Pins cross to 0.2.4 to stay compatible with the Rust 1.89.0 toolchain used in release builds. Bumps the Rust toolchain to 1.89.0 in CI, the release workflow, the server Dockerfile, and rust-toolchain.toml to match other repos. Keeps the aarch64 release build working while aligning versions.