### PR TITLE
Enforce VRF consume check for outside execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 on: push
 env:
   CARGO_TERM_COLOR: always
-  SCARB_VERSION: 2.12.2
+  SCARB_VERSION: 2.15.1
 jobs:
   fmt:
     runs-on: ubuntu-latest

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.12.2
-starknet-foundry 0.49.0
+scarb 2.15.1
+starknet-foundry 0.55.0
 starkli 0.4.2

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -107,9 +107,9 @@ checksum = "sha256:902932ec296c2f400e0ac7c579edeaafd6067b6ce6d9854c1191de28e396f
 
 [[package]]
 name = "openzeppelin_testing"
-version = "4.7.0"
+version = "6.3.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:3ee1e2bdfb6e01e638a5d96c820dfbc92c433271c39a8ed26ad9e96ff80fef90"
+checksum = "sha256:31baacf93656684a2c874ad7fe03c764b9e44426737a17b8d9d079acba4c1ef9"
 dependencies = [
  "snforge_std",
 ]
@@ -140,15 +140,15 @@ checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.49.0"
+version = "0.54.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:903150f0e9542e4277d417029eea4c03af0db398b581f9f7ae3ebbdac9afc657"
+checksum = "sha256:5c754ba8c262633e60c2cd06710cb96604c8bf20595fe60965013fedd8a55df9"
 
 [[package]]
 name = "snforge_std"
-version = "0.49.0"
+version = "0.54.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:73d73653cc4356ec51b92a6bec9d8385b20318170c2f2ade7891e5185a0e7e64"
+checksum = "sha256:e0532e6149ffc580e282d0774404e512a6814d477cd65529b91d5a09ac6e07d6"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -16,8 +16,8 @@ stark_vrf = "0.1.1"
 openzeppelin = "2.0.0"
 
 [dev-dependencies]
-openzeppelin_testing = "4.7.0"
-snforge_std = "0.49.0"
+openzeppelin_testing = "6.3.0"
+snforge_std = "0.54.1"
 
 [[target.starknet-contract]]
 

--- a/server/src/tests/test_outisde_execution.rs
+++ b/server/src/tests/test_outisde_execution.rs
@@ -205,7 +205,7 @@ async fn test_outside_execution(sequencer: &RunnerCtx) {
         .unwrap();
 
     println!("dice_value_after: {dice_value:?}");
-    assert!(dice_value[0] == felt!("0x4"), "dice should be 6")
+    assert!(dice_value[0] == felt!("0x5"), "dice should be 5")
 }
 
 pub fn mock_signed_outside_execution() -> SignedOutsideExecution {

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -9,9 +9,9 @@ pub mod vrf_consumer {
 }
 
 pub mod vrf_account {
+    pub mod src9;
     pub mod vrf_account;
     pub mod vrf_account_component;
-    pub mod src9;
 
     #[cfg(test)]
     pub mod tests {
@@ -39,4 +39,5 @@ pub use types::{PublicKey, Source};
 //     pub mod common;
 //     pub mod test_dice;
 // }
+
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -11,6 +11,7 @@ pub mod vrf_consumer {
 pub mod vrf_account {
     pub mod vrf_account;
     pub mod vrf_account_component;
+    pub mod src9;
 
     #[cfg(test)]
     pub mod tests {
@@ -38,5 +39,4 @@ pub use types::{PublicKey, Source};
 //     pub mod common;
 //     pub mod test_dice;
 // }
-
 

--- a/src/vrf_account/src9.cairo
+++ b/src/vrf_account/src9.cairo
@@ -13,7 +13,6 @@ pub mod SRC9Component {
     use openzeppelin::account::extensions::src9::snip12_utils::OutsideExecutionStructHash;
     use openzeppelin::account::extensions::src9::{OutsideExecution, interface};
     use openzeppelin::account::interface::{ISRC6Dispatcher, ISRC6DispatcherTrait};
-    use openzeppelin::account::utils::execute_calls;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin::utils::cryptography::snip12::{OffchainMessageHash, SNIP12Metadata};
@@ -117,10 +116,8 @@ pub mod SRC9Component {
             assert(is_valid_signature, Errors::INVALID_SIGNATURE);
 
             // 5. Execute the calls
-            let result = execute_calls(outside_execution.calls);
             let mut vrf_component = get_dep_component_mut!(ref self, VRF);
-            vrf_component.assert_consumed_if_submit_random(outside_execution.calls);
-            result
+            vrf_component.execute_and_assert_consumed_if_submit_random(outside_execution.calls)
         }
 
         /// Returns the status of a given nonce. `true` if the nonce is available to use.

--- a/src/vrf_account/src9.cairo
+++ b/src/vrf_account/src9.cairo
@@ -10,8 +10,8 @@
 /// interface.
 #[starknet::component]
 pub mod SRC9Component {
-    use openzeppelin::account::extensions::src9::{OutsideExecution, interface};
     use openzeppelin::account::extensions::src9::snip12_utils::OutsideExecutionStructHash;
+    use openzeppelin::account::extensions::src9::{OutsideExecution, interface};
     use openzeppelin::account::interface::{ISRC6Dispatcher, ISRC6DispatcherTrait};
     use openzeppelin::account::utils::execute_calls;
     use openzeppelin::introspection::src5::SRC5Component;

--- a/src/vrf_account/src9.cairo
+++ b/src/vrf_account/src9.cairo
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v3.0.0 (account/src/extensions/src9/src9.cairo)
+
+/// # SRC9 Component (Outside Execution)
+///
+/// The SRC9 component allows a protocol to submit transactions on behalf of a user account,
+/// as long as they provide the relevant signatures.
+///
+/// This component is designed to be account agnostic, as long as the contract implements the ISRC6
+/// interface.
+#[starknet::component]
+pub mod SRC9Component {
+    use openzeppelin::account::extensions::src9::{OutsideExecution, interface};
+    use openzeppelin::account::extensions::src9::snip12_utils::OutsideExecutionStructHash;
+    use openzeppelin::account::interface::{ISRC6Dispatcher, ISRC6DispatcherTrait};
+    use openzeppelin::account::utils::execute_calls;
+    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
+    use openzeppelin::utils::cryptography::snip12::{OffchainMessageHash, SNIP12Metadata};
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
+    use crate::vrf_account::vrf_account_component::VrfAccountComponent;
+    use crate::vrf_account::vrf_account_component::VrfAccountComponent::VrfOutsideExecutionTrait;
+
+    #[storage]
+    pub struct Storage {
+        pub SRC9_nonces: Map<felt252, bool>,
+    }
+
+    pub mod Errors {
+        pub const INVALID_CALLER: felt252 = 'SRC9: invalid caller';
+        pub const INVALID_AFTER: felt252 = 'SRC9: now <= execute_after';
+        pub const INVALID_BEFORE: felt252 = 'SRC9: now >= execute_before';
+        pub const DUPLICATED_NONCE: felt252 = 'SRC9: duplicated nonce';
+        pub const INVALID_SIGNATURE: felt252 = 'SRC9: invalid signature';
+    }
+
+    // Name and version as defined in the SNIP-9
+    pub impl SNIP12MetadataImpl of SNIP12Metadata {
+        fn name() -> felt252 {
+            'Account.execute_from_outside'
+        }
+        fn version() -> felt252 {
+            2
+        }
+    }
+
+    //
+    // External
+    //
+
+    #[embeddable_as(OutsideExecutionV2Impl)]
+    impl OutsideExecutionV2<
+        TContractState,
+        +HasComponent<TContractState>,
+        impl VRF: VrfAccountComponent::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of interface::ISRC9_V2<ComponentState<TContractState>> {
+        /// Allows anyone to submit a transaction on behalf of the account as long as they
+        /// provide the relevant signatures.
+        ///
+        /// This method allows reentrancy. A call to `__execute__` or `execute_from_outside_v2` can
+        /// trigger another nested transaction to `execute_from_outside_v2`. This implementation
+        /// verifies that the provided `signature` matches the hash of `outside_execution` and that
+        /// `nonce` was not already used.
+        ///
+        /// Arguments:
+        ///
+        /// - `outside_execution` - The parameters of the transaction to execute.
+        /// - `signature` - A valid signature on the SNIP-12 message encoding of
+        /// `outside_execution`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must be the `outside_execution.caller` unless 'ANY_CALLER' is used.
+        /// - The current time must be within the `outside_execution.execute_after` and
+        /// `outside_execution.execute_before` span, excluding boundaries.
+        /// - The `outside_execution.nonce` must not be used before.
+        /// - The `signature` must be valid.
+        fn execute_from_outside_v2(
+            ref self: ComponentState<TContractState>,
+            outside_execution: OutsideExecution,
+            signature: Span<felt252>,
+        ) -> Array<Span<felt252>> {
+            // 'ANY_CALLER' can be used to bypass the caller validation
+            if outside_execution.caller.into() != 'ANY_CALLER' {
+                assert(
+                    starknet::get_caller_address() == outside_execution.caller,
+                    Errors::INVALID_CALLER,
+                );
+            }
+
+            // 1. Validate the execution time span
+            let now = starknet::get_block_timestamp();
+            assert(outside_execution.execute_after < now, Errors::INVALID_AFTER);
+            assert(now < outside_execution.execute_before, Errors::INVALID_BEFORE);
+
+            // 2. Validate the nonce
+            assert(!self.SRC9_nonces.read(outside_execution.nonce), Errors::DUPLICATED_NONCE);
+
+            // 3. Mark the nonce as used
+            self.SRC9_nonces.write(outside_execution.nonce, true);
+
+            // 4. Validate the signature
+            let this = starknet::get_contract_address();
+            let outside_tx_hash = outside_execution.get_message_hash(this);
+
+            // Make this component agnostic to the account implementation, as long
+            // as the contract implements the SRC6 interface.
+            let is_valid_signature_felt = ISRC6Dispatcher { contract_address: this }
+                .is_valid_signature(outside_tx_hash, signature.into());
+
+            // Check either 'VALID' or true for backwards compatibility.
+            let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
+                || is_valid_signature_felt == 1;
+
+            assert(is_valid_signature, Errors::INVALID_SIGNATURE);
+
+            // 5. Execute the calls
+            let result = execute_calls(outside_execution.calls);
+            let mut vrf_component = get_dep_component_mut!(ref self, VRF);
+            vrf_component.assert_consumed_if_submit_random(outside_execution.calls);
+            result
+        }
+
+        /// Returns the status of a given nonce. `true` if the nonce is available to use.
+        fn is_valid_outside_execution_nonce(
+            self: @ComponentState<TContractState>, nonce: felt252,
+        ) -> bool {
+            !self.SRC9_nonces.read(nonce)
+        }
+    }
+
+    //
+    // Internal
+    //
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState,
+        +HasComponent<TContractState>,
+        impl SRC5: SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of InternalTrait<TContractState> {
+        /// Initializes the account by registering the ISRC9_V2 interface ID.
+        fn initializer(ref self: ComponentState<TContractState>) {
+            let mut src5_component = get_dep_component_mut!(ref self, SRC5);
+            src5_component.register_interface(interface::ISRC9_V2_ID);
+        }
+    }
+}

--- a/src/vrf_account/tests/test_dice.cairo
+++ b/src/vrf_account/tests/test_dice.cairo
@@ -10,9 +10,7 @@ use super::common::{ANY_CALLER, CONSUMER, CONSUMER_ACCOUNT, VRF_ACCOUNT, ZERO_AD
 #[starknet::interface]
 pub trait IOutsideExecutionV2<TContractState> {
     fn execute_from_outside_v2(
-        ref self: TContractState,
-        outside_execution: OutsideExecution,
-        signature: Span<felt252>,
+        ref self: TContractState, outside_execution: OutsideExecution, signature: Span<felt252>,
     ) -> Array<Span<felt252>>;
 }
 
@@ -138,11 +136,7 @@ fn test_outside_execution__must_consume() {
 
     let calls = array![sumbit_random, not_consuming];
     let outside_execution = OutsideExecution {
-        caller: ANY_CALLER,
-        nonce: 0,
-        execute_after: 0,
-        execute_before: 999,
-        calls: calls.span(),
+        caller: ANY_CALLER, nonce: 0, execute_after: 0, execute_before: 999, calls: calls.span(),
     };
     let signature = array![
         0x7fecf764944ad39da31b41682b815078d5121fd0c91370e9f9ebc0ac2611332,
@@ -150,6 +144,8 @@ fn test_outside_execution__must_consume() {
     ]
         .span();
 
-    let disp = IOutsideExecutionV2Dispatcher { contract_address: setup.vrf_account.contract_address };
+    let disp = IOutsideExecutionV2Dispatcher {
+        contract_address: setup.vrf_account.contract_address,
+    };
     disp.execute_from_outside_v2(outside_execution, signature);
 }

--- a/src/vrf_account/tests/test_dice.cairo
+++ b/src/vrf_account/tests/test_dice.cairo
@@ -7,6 +7,15 @@ use snforge_std::{
 use starknet::account::Call;
 use super::common::{ANY_CALLER, CONSUMER, CONSUMER_ACCOUNT, VRF_ACCOUNT, ZERO_ADDRESS, setup};
 
+#[starknet::interface]
+pub trait IOutsideExecutionV2<TContractState> {
+    fn execute_from_outside_v2(
+        ref self: TContractState,
+        outside_execution: OutsideExecution,
+        signature: Span<felt252>,
+    ) -> Array<Span<felt252>>;
+}
+
 
 #[test]
 fn test_multicall() {
@@ -102,4 +111,45 @@ fn test_vrf() {
 
     disp.__validate__(vrf_account_calls.clone());
     disp.__execute__(vrf_account_calls);
+}
+
+#[test]
+#[should_panic(expected: 'VrfProvider: not consumed')]
+fn test_outside_execution__must_consume() {
+    let setup = setup();
+
+    let sumbit_random = Call {
+        to: VRF_ACCOUNT,
+        selector: selector!("submit_random"),
+        calldata: array![
+            0x5db4e1c9bd8b0898674bf96f79e8fbffa3fe6d70a4597683c4dba2f0930dc45, // seed
+            // proof
+            0x16aec715f329872b75ca9beb77557ca6c9d3a67a01a3363df86496d2c3a261d,
+            0x22c44f72eccd63fb28a0e7bf3205f45130c57db28f9c35777e90ae5e414c246,
+            0x28bfff7440a8dcd8e86d260eff5aea305db55b9183109eff9f81a99e150e8ea,
+            0x16d49559522712102d3459c7999b0fabf24f2525b1a5e3f91d148a7a7256576,
+            0x5c87f6e05d61823e0646ff56675fab2e3c01b5b09deee479390d5a50ce34b83,
+        ]
+            .span(),
+    };
+    let not_consuming = Call {
+        to: CONSUMER, selector: selector!("not_consuming"), calldata: array![].span(),
+    };
+
+    let calls = array![sumbit_random, not_consuming];
+    let outside_execution = OutsideExecution {
+        caller: ANY_CALLER,
+        nonce: 0,
+        execute_after: 0,
+        execute_before: 999,
+        calls: calls.span(),
+    };
+    let signature = array![
+        0x7fecf764944ad39da31b41682b815078d5121fd0c91370e9f9ebc0ac2611332,
+        0x57fa6fef2cb679ebd9acf214490ac0d3a194513dfa73e81c341a1f8866029fb,
+    ]
+        .span();
+
+    let disp = IOutsideExecutionV2Dispatcher { contract_address: setup.vrf_account.contract_address };
+    disp.execute_from_outside_v2(outside_execution, signature);
 }

--- a/src/vrf_account/vrf_account.cairo
+++ b/src/vrf_account/vrf_account.cairo
@@ -3,11 +3,12 @@
 
 #[starknet::contract(account)]
 mod VrfAccount {
-    use openzeppelin::account::extensions::SRC9Component;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::{IUpgradeAndCall, IUpgradeable};
     use starknet::ClassHash;
+
+    use crate::vrf_account::src9::SRC9Component;
     use crate::vrf_account::vrf_account_component::VrfAccountComponent;
 
     component!(path: VrfAccountComponent, storage: vrf_provider, event: VrfProviderEvent);

--- a/src/vrf_account/vrf_account.cairo
+++ b/src/vrf_account/vrf_account.cairo
@@ -7,7 +7,6 @@ mod VrfAccount {
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::{IUpgradeAndCall, IUpgradeable};
     use starknet::ClassHash;
-
     use crate::vrf_account::src9::SRC9Component;
     use crate::vrf_account::vrf_account_component::VrfAccountComponent;
 

--- a/src/vrf_account/vrf_account_component.cairo
+++ b/src/vrf_account/vrf_account_component.cairo
@@ -273,6 +273,30 @@ pub mod VrfAccountComponent {
         }
     }
 
+    #[generate_trait]
+    pub impl VrfOutsideExecutionImpl<
+        TContractState,
+        +HasComponent<TContractState>,
+        impl SRC5: SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of VrfOutsideExecutionTrait<TContractState> {
+        fn assert_consumed_if_submit_random(
+            ref self: ComponentState<TContractState>, calls: Span<Call>,
+        ) {
+            let mut should_assert_consumed_seed = Option::None;
+            for call in calls {
+                if self._is_submit_random_call(call) {
+                    should_assert_consumed_seed = Option::Some(call.calldata.at(0));
+                }
+            }
+
+            if should_assert_consumed_seed.is_some() {
+                let seed = *should_assert_consumed_seed.unwrap();
+                self._assert_consumed(seed);
+            }
+        }
+    }
+
     //
     // External
     //

--- a/src/vrf_account/vrf_account_component.cairo
+++ b/src/vrf_account/vrf_account_component.cairo
@@ -280,20 +280,24 @@ pub mod VrfAccountComponent {
         impl SRC5: SRC5Component::HasComponent<TContractState>,
         +Drop<TContractState>,
     > of VrfOutsideExecutionTrait<TContractState> {
-        fn assert_consumed_if_submit_random(
+        fn execute_and_assert_consumed_if_submit_random(
             ref self: ComponentState<TContractState>, calls: Span<Call>,
-        ) {
+        ) -> Array<Span<felt252>> {
             let mut should_assert_consumed_seed = Option::None;
+            let mut results = array![];
             for call in calls {
                 if self._is_submit_random_call(call) {
                     should_assert_consumed_seed = Option::Some(call.calldata.at(0));
                 }
+                results.append(execute_single_call(call));
             }
 
             if should_assert_consumed_seed.is_some() {
                 let seed = *should_assert_consumed_seed.unwrap();
                 self._assert_consumed(seed);
             }
+
+            results
         }
     }
 
@@ -322,18 +326,7 @@ pub mod VrfAccountComponent {
             assert(sender.is_zero(), Errors::INVALID_CALLER);
             assert(is_tx_version_valid(), Errors::INVALID_TX_VERSION);
 
-            let mut should_assert_consumed_seed = Option::None;
-            for call in calls.span() {
-                if self._is_submit_random_call(call) {
-                    should_assert_consumed_seed = Option::Some(call.calldata.at(0));
-                }
-                execute_single_call(call);
-            }
-
-            if should_assert_consumed_seed.is_some() {
-                let seed = *should_assert_consumed_seed.unwrap();
-                self._assert_consumed(seed);
-            }
+            let _ = self.execute_and_assert_consumed_if_submit_random(calls.span());
         }
 
         /// Verifies the validity of the signature for the current transaction.


### PR DESCRIPTION
Enforce VRF consume checks for SRC9 outside execution by invoking a shared VrfAccount execution hook that runs calls and asserts consumption. Add a regression test that fails when submit_random is called via outside execution without consuming. Update dev tooling versions (snforge_std/openzeppelin_testing, Scarb tool versions) and bump CI Scarb to keep builds/tests running, plus apply Cairo formatting fixes. Adjust the server outside-execution test expectation to match the updated VRF behavior.