### PR TITLE
fix: use untagged serde for `OutsideExecution` enum

### DIFF
--- a/server/src/routes/outside_execution/mod.rs
+++ b/server/src/routes/outside_execution/mod.rs
@@ -194,7 +194,7 @@ impl From<url::ParseError> for Errors {
     }
 }
 
-// curl -X POST -H "Content-Type: application/json" -d '{"request" : {"address":"0x111","outside_execution":{"V3":{"caller":"0x414e595f43414c4c4552","calls":[{"calldata":["0x111","0x0","0x222"],"selector":"0x12a5a2e008479001f8f1a5f6c61ab6536d5ce46571fcdc0c9300dca0a9e532f","to":"0x888"},{"calldata":[],"selector":"0x1f9ca87172ecd8343d776bdd6024a4028f5596c76320882abd93e3bd1c724eb","to":"0x111"}],"execute_after":"0x0","execute_before":"0xb2d05e00","nonce":["0x564b73282b2fb5f201cf2070bf0ca2526871cb7daa06e0e805521ef5d907b33","0xa"]}},"signature":["0x12345","0x67890"]}}' http://0.0.0.0:3000/outside_execution
+// curl -X POST -H "Content-Type: application/json" -d '{"request" : {"address":"0x111","outside_execution":{"caller":"0x414e595f43414c4c4552","calls":[{"calldata":["0x111","0x0","0x222"],"selector":"0x12a5a2e008479001f8f1a5f6c61ab6536d5ce46571fcdc0c9300dca0a9e532f","to":"0x888"},{"calldata":[],"selector":"0x1f9ca87172ecd8343d776bdd6024a4028f5596c76320882abd93e3bd1c724eb","to":"0x111"}],"execute_after":"0x0","execute_before":"0xb2d05e00","nonce":["0x564b73282b2fb5f201cf2070bf0ca2526871cb7daa06e0e805521ef5d907b33","0xa"]},"signature":["0x12345","0x67890"]}}' http://0.0.0.0:3000/outside_execution
 
 #[cfg(test)]
 pub mod test {

--- a/server/src/routes/outside_execution/types.rs
+++ b/server/src/routes/outside_execution/types.rs
@@ -93,7 +93,7 @@ pub struct OutsideExecutionV3 {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-// #[serde(untagged)]
+#[serde(untagged)]
 pub enum OutsideExecution {
     /// SNIP-9 standard version.
     V2(OutsideExecutionV2),

--- a/server/src/tests/test_outisde_execution.rs
+++ b/server/src/tests/test_outisde_execution.rs
@@ -311,7 +311,6 @@ async fn test_with_invalid_json_value() {
       "request": {
         "address": "0x111",
         "outside_execution": {
-          "V3": {
             "caller": "0x414e595f43414c4c4552",
             "calls": [
               {
@@ -331,7 +330,6 @@ async fn test_with_invalid_json_value() {
               "0x564b73282b2fb5f201cf2070bf0ca2526871cb7daa06e0e805521ef5d907b33",
               "0xa"
             ]
-          }
         },
         "signature": ["0x12345", "0x67890"]
       },


### PR DESCRIPTION
## Summary

- Uncomment `#[serde(untagged)]` on the `OutsideExecution` enum so it serializes as flat variant fields (e.g. `{"caller": "0x...", "nonce": [...]}`) instead of tagged format (`{"V3": {"caller": "0x...", ...}}`)
- Update test JSON and curl example to match the new untagged format

This aligns the VRF server's serialization with [controller-rs](https://github.com/cartridge-gg/controller-rs/blob/44f18f37d71eb10ed5a0df96d52c9481233c66ff/account_sdk/src/account/outside_execution.rs#L31-L57) where `OutsideExecution` uses custom serde that serializes variant data directly without a tag.

## Test plan
- [x] `cargo check` passes
- [ ] Existing integration tests pass with updated JSON format

🤖 Generated with [Claude Code](https://claude.com/claude-code)