### PR TITLE
fix: remove V3 outside execution signing

### DIFF
--- a/server/src/routes/outside_execution/mod.rs
+++ b/server/src/routes/outside_execution/mod.rs
@@ -5,8 +5,7 @@ pub mod vrf_types;
 use crate::routes::outside_execution::context::{RequestContext, VrfContext};
 use crate::routes::outside_execution::signature::sign_outside_execution;
 use crate::routes::outside_execution::types::{
-    get_calls, Call, OutsideExecution, OutsideExecutionV2, OutsideExecutionV3,
-    SignedOutsideExecution,
+    get_calls, Call, OutsideExecution, OutsideExecutionV2, SignedOutsideExecution,
 };
 use crate::routes::outside_execution::vrf_types::{build_submit_random_call, RequestRandom};
 use crate::state::SharedState;
@@ -77,26 +76,13 @@ pub async fn vrf_outside_execution(
 
     let calls = vec![sumbit_random_call, execute_from_outside_call];
 
-    let signed_outside_execution = match &outside_execution {
-        OutsideExecution::V2(_) => {
-            build_signed_outside_execution_v2(
-                vrf_context.vrf_account_address.0,
-                vrf_context.vrf_signer,
-                vrf_context.chain_id,
-                calls,
-            )
-            .await
-        }
-        OutsideExecution::V3(_) => {
-            build_signed_outside_execution_v3(
-                vrf_context.vrf_account_address.0,
-                vrf_context.vrf_signer,
-                vrf_context.chain_id,
-                calls,
-            )
-            .await
-        }
-    };
+    let signed_outside_execution = build_signed_outside_execution_v2(
+        vrf_context.vrf_account_address.0,
+        vrf_context.vrf_signer,
+        vrf_context.chain_id,
+        calls,
+    )
+    .await;
 
     Ok(Json(OutsideExecutionResult {
         result: signed_outside_execution,
@@ -128,35 +114,6 @@ pub fn build_outside_execution_v2(calls: Vec<Call>) -> OutsideExecution {
         execute_before: now + 600,
         calls,
         nonce: SigningKey::from_random().secret_scalar(),
-    })
-}
-
-pub async fn build_signed_outside_execution_v3(
-    account_address: Felt,
-    signer: LocalWallet,
-    chain_id: Felt,
-    calls: Vec<Call>,
-) -> SignedOutsideExecution {
-    let outside_execution = build_outside_execution_v3(calls);
-
-    let signature =
-        sign_outside_execution(&outside_execution, chain_id, account_address, signer).await;
-
-    SignedOutsideExecution {
-        address: account_address,
-        outside_execution,
-        signature,
-    }
-}
-
-pub fn build_outside_execution_v3(calls: Vec<Call>) -> OutsideExecution {
-    let now = Utc::now().timestamp() as u64;
-    OutsideExecution::V3(OutsideExecutionV3 {
-        caller: ANY_CALLER,
-        execute_after: 0,
-        execute_before: now + 600,
-        calls,
-        nonce: (SigningKey::from_random().secret_scalar(), 0),
     })
 }
 
@@ -242,7 +199,7 @@ impl From<url::ParseError> for Errors {
 #[cfg(test)]
 pub mod test {
     use crate::routes::outside_execution::{
-        types::{Call, OutsideExecution, OutsideExecutionV3, SignedOutsideExecution},
+        types::{Call, OutsideExecution, OutsideExecutionV2, SignedOutsideExecution},
         ANY_CALLER,
     };
     use starknet::macros::{felt, selector};
@@ -251,7 +208,7 @@ pub mod test {
     fn outside_execution_serialization() {
         let signed_outside_execution = SignedOutsideExecution {
             address: felt!("0x111"),
-            outside_execution: OutsideExecution::V3(OutsideExecutionV3 {
+            outside_execution: OutsideExecution::V2(OutsideExecutionV2 {
                 caller: ANY_CALLER,
                 execute_after: 0,
                 execute_before: 3000000000,
@@ -271,10 +228,7 @@ pub mod test {
                         calldata: vec![],
                     },
                 ],
-                nonce: (
-                    felt!("0x564b73282b2fb5f201cf2070bf0ca2526871cb7daa06e0e805521ef5d907b33"),
-                    10,
-                ),
+                nonce: felt!("0x564b73282b2fb5f201cf2070bf0ca2526871cb7daa06e0e805521ef5d907b33"),
             }),
             signature: vec![felt!("0x12345"), felt!("0x67890")],
         };

--- a/server/src/routes/outside_execution/signature.rs
+++ b/server/src/routes/outside_execution/signature.rs
@@ -1,7 +1,6 @@
 // Delegates SNIP-12 message hashing to account_sdk:
 // https://github.com/cartridge-gg/controller-rs/blob/main/account_sdk/src/account/outside_execution.rs
 // https://github.com/cartridge-gg/controller-rs/blob/main/account_sdk/src/account/outside_execution_v2.rs
-// https://github.com/cartridge-gg/controller-rs/blob/main/account_sdk/src/account/outside_execution_v3.rs
 
 use account_sdk::hash::MessageHashRev1;
 use starknet::signers::{LocalWallet, Signer};
@@ -25,7 +24,7 @@ pub async fn sign_outside_execution(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routes::outside_execution::types::{Call, OutsideExecutionV2, OutsideExecutionV3};
+    use crate::routes::outside_execution::types::{Call, OutsideExecutionV2};
     use cainome_cairo_serde::ContractAddress;
     use starknet::macros::{felt, selector};
     use starknet::signers::SigningKey;
@@ -67,16 +66,6 @@ mod tests {
         })
     }
 
-    fn test_outside_execution_v3() -> OutsideExecution {
-        OutsideExecution::V3(OutsideExecutionV3 {
-            caller: TEST_CALLER,
-            nonce: (felt!("0x1"), 0),
-            execute_after: 0,
-            execute_before: 3000000000,
-            calls: test_calls(),
-        })
-    }
-
     #[tokio::test]
     async fn sign_v2_produces_valid_signature() {
         let oe = test_outside_execution_v2();
@@ -91,23 +80,6 @@ mod tests {
         assert!(
             starknet_crypto::verify(&public_key, &hash, &sig[0], &sig[1]).unwrap(),
             "V2 signature should be valid"
-        );
-    }
-
-    #[tokio::test]
-    async fn sign_v3_produces_valid_signature() {
-        let oe = test_outside_execution_v3();
-        let sig =
-            sign_outside_execution(&oe, TEST_CHAIN_ID, TEST_SIGNER_ADDRESS, test_signer()).await;
-
-        assert_eq!(sig.len(), 2, "signature should have r and s components");
-
-        let hash = oe.get_message_hash_rev_1(TEST_CHAIN_ID, TEST_SIGNER_ADDRESS);
-        let public_key = test_signing_key().verifying_key().scalar();
-
-        assert!(
-            starknet_crypto::verify(&public_key, &hash, &sig[0], &sig[1]).unwrap(),
-            "V3 signature should be valid"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Always build and sign the VRF account's wrapping outside execution as V2, removing V3 signing support
- Incoming requests can still be V2 or V3 (deserialization unchanged)
- Remove `build_signed_outside_execution_v3`, `build_outside_execution_v3`, and V3 signing tests

## Test plan
- [x] `cargo build` compiles cleanly
- [x] Unit tests pass (`sign_v2_produces_valid_signature`, `outside_execution_serialization`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)