### PR TITLE
feat: update logging format to match katana

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.195", features = ["serde_derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tower-http = { version = "0.5.0", features = ["trace", "cors"] }
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 prost = "0.12.3"
 stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git" }
 num = "0.4.3"

--- a/server/src/fmt.rs
+++ b/server/src/fmt.rs
@@ -1,0 +1,20 @@
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time;
+
+const DEFAULT_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f %Z";
+
+#[derive(Debug, Clone, Default)]
+pub struct LocalTime;
+
+impl LocalTime {
+    pub fn new() -> Self {
+        LocalTime
+    }
+}
+
+impl time::FormatTime for LocalTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        let time = chrono::Local::now();
+        write!(w, "{}", time.format(DEFAULT_TIMESTAMP_FORMAT))
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -105,10 +105,14 @@ async fn main() {
     let args = Args::parse();
 
     let default_filter = EnvFilter::try_new("info");
-    let filter =
-        EnvFilter::try_from_default_env().or(default_filter).expect("failed to parse log filter");
+    let filter = EnvFilter::try_from_default_env()
+        .or(default_filter)
+        .expect("failed to parse log filter");
 
-    tracing_subscriber::fmt().with_env_filter(filter).with_timer(LocalTime::new()).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_timer(LocalTime::new())
+        .init();
 
     let app_state = AppState::new().await;
     let app = create_app(app_state).await;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,4 @@
+pub mod fmt;
 pub mod oracle;
 pub mod routes;
 pub mod state;
@@ -24,6 +25,9 @@ use std::sync::{Arc, RwLock};
 use tokio::signal;
 use tower_http::trace::TraceLayer;
 use tracing::debug;
+use tracing_subscriber::EnvFilter;
+
+use crate::fmt::LocalTime;
 
 #[derive(Parser, Debug)]
 #[command(version = version::generate_short(), long_version = version::generate_long(), about, long_about = None)]
@@ -100,9 +104,11 @@ pub async fn create_app(app_state: AppState) -> Router {
 async fn main() {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .init();
+    let default_filter = EnvFilter::try_new("info");
+    let filter =
+        EnvFilter::try_from_default_env().or(default_filter).expect("failed to parse log filter");
+
+    tracing_subscriber::fmt().with_env_filter(filter).with_timer(LocalTime::new()).init();
 
     let app_state = AppState::new().await;
     let app = create_app(app_state).await;


### PR DESCRIPTION
## Summary
- Add `LocalTime` formatter using `chrono` to produce local timestamps (`%Y-%m-%d %H:%M:%S%.3f %Z`), matching katana's tracing format
- Replace hardcoded `DEBUG` max level with `EnvFilter` supporting `RUST_LOG` env var (defaults to `info`)
- Add `env-filter` feature to `tracing-subscriber`

## Test plan
- [ ] `cargo check` passes
- [ ] Server starts and logs use local timestamps
- [ ] `RUST_LOG=debug cargo run` enables debug-level output

🤖 Generated with [Claude Code](https://claude.com/claude-code)