### PR TITLE
feat: add OpenTelemetry distributed tracing

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2457,6 +2457,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3438,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest 0.12.23",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "reqwest 0.12.23",
+ "thiserror 2.0.17",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,7 +3851,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -3779,7 +3878,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost",
+ "prost 0.12.6",
  "prost-types",
  "regex",
  "syn 2.0.106",
@@ -3800,12 +3899,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -4098,7 +4210,9 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4119,7 +4233,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower",
- "tower-http 0.6.6",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5594,6 +5708,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5601,26 +5741,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.7.1",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.9.4",
- "bytes",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5642,6 +5768,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5698,6 +5825,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -6012,9 +6157,14 @@ dependencies = [
  "clap",
  "const_format",
  "dojo-utils",
+ "http 1.3.1",
  "katana-runner",
  "num",
- "prost",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "prost 0.12.6",
  "prost-build",
  "serde",
  "serde_json",
@@ -6022,8 +6172,9 @@ dependencies = [
  "starknet",
  "starknet-crypto 0.8.1",
  "tokio",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "vergen",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,9 +12,15 @@ ark-ec = "0.4.2"
 axum = "0.8.4"
 serde = { version = "1.0.195", features = ["serde_derive"] }
 tokio = { version = "1.40", features = ["full"] }
-tower-http = { version = "0.5.0", features = ["trace", "cors"] }
+tower-http = { version = "0.6", features = ["trace", "cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-opentelemetry = "0.31"
+opentelemetry = { version = "0.30", features = ["trace"] }
+opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic"] }
+opentelemetry-http = "0.30"
+http = "1"
 prost = "0.12.3"
 stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git" }
 num = "0.4.3"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,6 +2,7 @@ pub mod fmt;
 pub mod oracle;
 pub mod routes;
 pub mod state;
+pub mod telemetry;
 pub mod utils;
 pub mod version;
 
@@ -25,9 +26,8 @@ use std::sync::{Arc, RwLock};
 use tokio::signal;
 use tower_http::trace::TraceLayer;
 use tracing::debug;
-use tracing_subscriber::EnvFilter;
 
-use crate::fmt::LocalTime;
+use crate::telemetry::{OtelMakeSpan, OtlpConfig};
 
 #[derive(Parser, Debug)]
 #[command(version = version::generate_short(), long_version = version::generate_long(), about, long_about = None)]
@@ -51,6 +51,22 @@ pub struct Args {
     /// Account Private Key
     #[arg(long, required = true)]
     account_private_key: String,
+
+    /// Enable the OpenTelemetry Protocol (OTLP) trace exporter.
+    #[arg(long = "tracer.otlp")]
+    tracer_otlp: bool,
+
+    /// OTLP collector endpoint (defaults to `http://localhost:4317`).
+    #[arg(long = "tracer.otlp-endpoint", requires = "tracer_otlp", value_name = "URL")]
+    otlp_endpoint: Option<String>,
+}
+
+impl Args {
+    fn otlp_config(&self) -> Option<OtlpConfig> {
+        self.tracer_otlp.then(|| OtlpConfig {
+            endpoint: self.otlp_endpoint.clone(),
+        })
+    }
 }
 
 impl Default for Args {
@@ -61,6 +77,8 @@ impl Default for Args {
             account_address: "0x123".into(),
             account_private_key: "0x420".into(),
             secret_key: 420,
+            tracer_otlp: false,
+            otlp_endpoint: None,
         }
     }
 }
@@ -96,7 +114,7 @@ pub async fn create_app(app_state: AppState) -> Router {
         .route("/info", get(vrf_info))
         .route("/proof", post(vrf_proof))
         .route("/outside_execution", post(vrf_outside_execution))
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http().make_span_with(OtelMakeSpan))
         .with_state(shared_state)
 }
 
@@ -104,15 +122,7 @@ pub async fn create_app(app_state: AppState) -> Router {
 async fn main() {
     let args = Args::parse();
 
-    let default_filter = EnvFilter::try_new("info");
-    let filter = EnvFilter::try_from_default_env()
-        .or(default_filter)
-        .expect("failed to parse log filter");
-
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_timer(LocalTime::new())
-        .init();
+    telemetry::init(args.otlp_config()).expect("failed to initialize telemetry");
 
     let app_state = AppState::new().await;
     let app = create_app(app_state).await;
@@ -128,6 +138,9 @@ async fn main() {
         .with_graceful_shutdown(shutdown_signal())
         .await
         .unwrap();
+
+    // Flush any buffered OTLP spans before exiting.
+    telemetry::shutdown();
 }
 
 async fn shutdown_signal() {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -57,7 +57,11 @@ pub struct Args {
     tracer_otlp: bool,
 
     /// OTLP collector endpoint (defaults to `http://localhost:4317`).
-    #[arg(long = "tracer.otlp-endpoint", requires = "tracer_otlp", value_name = "URL")]
+    #[arg(
+        long = "tracer.otlp-endpoint",
+        requires = "tracer_otlp",
+        value_name = "URL"
+    )]
     otlp_endpoint: Option<String>,
 }
 

--- a/server/src/telemetry.rs
+++ b/server/src/telemetry.rs
@@ -1,0 +1,200 @@
+//! Distributed tracing for vrf-server.
+//!
+//! Mirrors katana's conventions (`dojoengine/katana/crates/tracing`):
+//! a layered `tracing-subscriber` with an optional OpenTelemetry OTLP
+//! exporter, and a `tower-http` `MakeSpan` that extracts W3C trace
+//! context from incoming HTTP headers so spans chain across services.
+
+use std::sync::OnceLock;
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_http::HeaderExtractor;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::{RandomIdGenerator, SdkTracerProvider};
+use opentelemetry_sdk::Resource;
+use tower_http::trace::MakeSpan;
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+
+use crate::fmt::LocalTime;
+
+const SERVICE_NAME: &str = "vrf-server";
+
+static PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+/// OTLP exporter configuration.
+#[derive(Debug, Clone, Default)]
+pub struct OtlpConfig {
+    /// OTLP collector endpoint. If `None`, defaults to the OTLP default
+    /// (typically `http://localhost:4317`).
+    pub endpoint: Option<String>,
+}
+
+/// `tower-http` `MakeSpan` that extracts the W3C trace context from inbound
+/// HTTP headers and makes it the parent of the new request span.
+///
+/// If no propagator is globally installed (OTLP disabled) or the headers
+/// contain no `traceparent`, the extracted context is empty and the span
+/// starts as a fresh root — no panic, no-op.
+#[derive(Debug, Clone, Default)]
+pub struct OtelMakeSpan;
+
+impl<B> MakeSpan<B> for OtelMakeSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> Span {
+        let cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(request.headers()))
+        });
+        let span = tracing::info_span!(
+            "http_request",
+            method = %request.method(),
+            uri = %request.uri(),
+        );
+        span.set_parent(cx);
+        span
+    }
+}
+
+fn init_otlp_tracer(
+    config: &OtlpConfig,
+) -> anyhow::Result<(opentelemetry_sdk::trace::Tracer, SdkTracerProvider)> {
+    use opentelemetry_otlp::WithExportConfig;
+
+    let mut builder = opentelemetry_otlp::SpanExporter::builder().with_tonic();
+    if let Some(endpoint) = &config.endpoint {
+        builder = builder.with_endpoint(endpoint.clone());
+    }
+    let exporter = builder.build()?;
+
+    let provider = SdkTracerProvider::builder()
+        .with_id_generator(RandomIdGenerator::default())
+        .with_batch_exporter(exporter)
+        .with_resource(Resource::builder().with_service_name(SERVICE_NAME).build())
+        .build();
+
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let tracer = provider.tracer(SERVICE_NAME);
+    opentelemetry::global::set_tracer_provider(provider.clone());
+    Ok((tracer, provider))
+}
+
+/// Initialize the global tracing subscriber.
+///
+/// When `otlp` is `Some`, an OpenTelemetry OTLP (gRPC) exporter is installed
+/// alongside the default stdout fmt layer and a W3C text-map propagator.
+/// When `otlp` is `None`, only the stdout fmt layer is installed.
+pub fn init(otlp: Option<OtlpConfig>) -> anyhow::Result<()> {
+    let default_filter = EnvFilter::try_new("info").expect("valid default filter");
+    let filter = EnvFilter::try_from_default_env().unwrap_or(default_filter);
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_timer(LocalTime::new());
+
+    let telemetry_layer = match otlp {
+        Some(config) => {
+            let (tracer, provider) = init_otlp_tracer(&config)?;
+            let _ = PROVIDER.set(provider);
+            Some(tracing_opentelemetry::layer().with_tracer(tracer))
+        }
+        None => None,
+    };
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(telemetry_layer)
+        .with(fmt_layer)
+        .init();
+
+    Ok(())
+}
+
+/// Flush and shut down the OTLP tracer provider, if one was installed.
+///
+/// Call this on graceful shutdown so the batch exporter flushes tail spans
+/// before the process exits. No-op when OTLP wasn't enabled.
+pub fn shutdown() {
+    if let Some(provider) = PROVIDER.get() {
+        let _ = provider.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::trace::TraceContextExt;
+    use opentelemetry::Context;
+
+    use super::*;
+
+    /// Ensure the global W3C propagator is installed for these tests.
+    /// Tests share process state, so this is idempotent.
+    fn ensure_propagator() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+        });
+    }
+
+    /// Extract the parent context directly from request headers the same way
+    /// `OtelMakeSpan::make_span` does, so we can assert on propagator output
+    /// without needing a full `tracing_opentelemetry` layer installed.
+    fn extract_parent<B>(req: &http::Request<B>) -> Context {
+        opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(req.headers()))
+        })
+    }
+
+    #[test]
+    fn make_span_without_traceparent_is_root() {
+        ensure_propagator();
+        let req = http::Request::builder().uri("/info").body(()).unwrap();
+
+        // Call make_span to exercise the real code path (must not panic).
+        let _ = OtelMakeSpan.make_span(&req);
+
+        // No traceparent header → propagator returns an empty context.
+        let cx = extract_parent(&req);
+        let otel_span = cx.span();
+        assert!(!otel_span.span_context().is_valid());
+    }
+
+    #[test]
+    fn make_span_with_valid_traceparent_is_child() {
+        ensure_propagator();
+        let trace_id_hex = "0af7651916cd43dd8448eb211c80319c";
+        let req = http::Request::builder()
+            .uri("/proof")
+            .header(
+                "traceparent",
+                format!("00-{trace_id_hex}-b7ad6b7169203331-01"),
+            )
+            .body(())
+            .unwrap();
+
+        let _ = OtelMakeSpan.make_span(&req);
+
+        let cx = extract_parent(&req);
+        let otel_span = cx.span();
+        let sc = otel_span.span_context();
+        assert!(sc.is_valid(), "remote span context should be valid");
+        assert_eq!(sc.trace_id().to_string(), trace_id_hex);
+    }
+
+    #[test]
+    fn make_span_with_malformed_traceparent_does_not_panic() {
+        ensure_propagator();
+        let req = http::Request::builder()
+            .uri("/info")
+            .header("traceparent", "garbage-not-a-valid-header")
+            .body(())
+            .unwrap();
+
+        // Must not panic.
+        let _ = OtelMakeSpan.make_span(&req);
+
+        let cx = extract_parent(&req);
+        let otel_span = cx.span();
+        assert!(!otel_span.span_context().is_valid());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds OTLP (gRPC/tonic) trace export following katana's conventions — spans from katana, paymaster-service, and vrf-server will stitch together on a single `trace_id` in the collector
- Extracts W3C `traceparent` from inbound HTTP headers and makes it the parent of every request's root span
- Opt-in via `--tracer.otlp` / `--tracer.otlp-endpoint` CLI flags; default behavior is unchanged when OTLP is disabled

## Details

New `src/telemetry.rs` module mirrors the shape of `dojoengine/katana/crates/tracing`:

- `OtlpConfig` — endpoint config (defaults to `http://localhost:4317`)
- `OtelMakeSpan` — `tower_http::trace::MakeSpan` that extracts trace context via the global propagator and calls `span.set_parent(cx)`
- `init(Option<OtlpConfig>)` — builds a layered subscriber (`registry + env_filter + optional telemetry_layer + fmt_layer`), sets the global tracer provider, installs the W3C `TraceContextPropagator`
- `shutdown()` — flushes the batch exporter on graceful shutdown via a `OnceLock<SdkTracerProvider>` (OTel 0.30 removed the free `shutdown_tracer_provider()` function)

`main.rs` wires the new module: adds CLI flags, replaces the old `tracing_subscriber::fmt().init()`, swaps `TraceLayer::new_for_http()` for `.make_span_with(OtelMakeSpan)`, and calls `telemetry::shutdown()` after `axum::serve` returns.

`tower-http` bumped 0.5 → 0.6 (required by axum 0.8 / the newer `MakeSpan` trait).

The service name reported to the collector is `vrf-server`.

## Test plan

- [x] `cargo build --bin vrf-server` clean
- [x] `cargo test --bin vrf-server telemetry::` — 3/3 passing
  - `make_span_without_traceparent_is_root`
  - `make_span_with_valid_traceparent_is_child` (trace_id matches `0af7651916cd43dd8448eb211c80319c`)
  - `make_span_with_malformed_traceparent_does_not_panic`
- [ ] Manual end-to-end: run with `--tracer.otlp --tracer.otlp-endpoint http://localhost:4317` pointing at an OTLP collector (Jaeger/Tempo/otel-collector), send a `POST /proof` with a synthetic `traceparent` header, confirm the exported span carries that trace_id

## Related

Companion PR against `cartridge-gg/paymaster` wires the same conventions into paymaster-service so all three services (katana, paymaster, vrf-server) emit spans under one trace_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)