### PR TITLE
chore(deps): bump openzeppelin 2.0.0 → 3.0.0

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -6,21 +6,21 @@ name = "cartridge_vrf"
 version = "0.1.0"
 dependencies = [
  "openzeppelin",
- "openzeppelin_testing",
  "snforge_std",
  "stark_vrf",
 ]
 
 [[package]]
 name = "openzeppelin"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:5e4fdecc957cfca7854d95912dc72d9f725517c063b116512900900add29fd77"
+checksum = "sha256:ded6f53e0b50a3583f72c556d9ca508e627d175c6f01a2f5124f2e9a052ac985"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_finance",
  "openzeppelin_governance",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_merkle_tree",
  "openzeppelin_presets",
@@ -32,67 +32,80 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:511681dd26d814ee2bc996d44ff8cb4aaa5ae9d14272130def7eb901cf004850"
+checksum = "sha256:2c7fab22d2601fca4f456c81272637f2563a423652d1671383bbe3d007803977"
 dependencies = [
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
 ]
 
 [[package]]
 name = "openzeppelin_account"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:fb3381c50d68b028d3801feb43df378e2bd62137b6884844f8f60aefe796188b"
+checksum = "sha256:b46f41be21fff6692d32949664d2f0dd1919c741346a676d6e0f1fe2ea576999"
 dependencies = [
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_finance"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:e9456ef69502a87c4c99bf50145351b50950f8b11244847d92935c466c4ba787"
+checksum = "sha256:f77f4f5262666d8033f16b3a7df839ed2abb699a09ad33099c7bb6bf2807fec1"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_interfaces",
  "openzeppelin_token",
 ]
 
 [[package]]
 name = "openzeppelin_governance"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:056e6d6f3d48193b53f06283884f8a9675f986fc85425f6a40e8c1aeb3b3ecfa"
+checksum = "sha256:b76c87f72b1481a62e3c6904a9a3da5cfc4de8b5a86a4742de30f1e2984c7e2b"
 dependencies = [
  "openzeppelin_access",
- "openzeppelin_account",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_utils",
 ]
 
 [[package]]
-name = "openzeppelin_introspection"
-version = "2.0.0"
+name = "openzeppelin_interfaces"
+version = "2.1.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:87773ed6cd2318f169283ecbbb161890d1996260a80302d81ec45b70ee5e54c1"
+checksum = "sha256:f69fdb36eb894a0e0732385e723c5ff56d8cb4c1d49b29446c77eefac00b02a5"
+
+[[package]]
+name = "openzeppelin_introspection"
+version = "3.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:ee491981a69736cde220f8b7dd290b6d8620c85ee6b83c81f665f5bef78b62b1"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "openzeppelin_merkle_tree"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:47f80c9ce59557774243214f8e75c5e866f30f3d8daa755855f6ffd01c89ca89"
+checksum = "sha256:3417680a1f672bd6cfb54962481f6b96d72f6510be2658d17c8356709b5c950a"
 
 [[package]]
 name = "openzeppelin_presets"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:36c761ee923f1dc0887c0eab8c224b49ac242dbfe9163fbb0b08562042ab3d98"
+checksum = "sha256:1facc433476df1c36ecb33e3a10b6a5fb219c670c437b43696788843fbc0bc25"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_finance",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_upgrades",
@@ -101,42 +114,39 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_security"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:902932ec296c2f400e0ac7c579edeaafd6067b6ce6d9854c1191de28e396ffe3"
-
-[[package]]
-name = "openzeppelin_testing"
-version = "6.3.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:31baacf93656684a2c874ad7fe03c764b9e44426737a17b8d9d079acba4c1ef9"
+checksum = "sha256:470f2debae50e03f1435874bc697a0825c257edcad4d1a0cc134e40360e6aba8"
 dependencies = [
- "snforge_std",
+ "openzeppelin_interfaces",
 ]
 
 [[package]]
 name = "openzeppelin_token"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:6fe61f63b5a6706018265fb7373b6e5bd3ff829bdc760b2b90296b1e708d180c"
+checksum = "sha256:5ce19d297251d9f11acc38a3e3e2faeb2e73b003c8de2f02c7c5d06d9161a5fc"
 dependencies = [
  "openzeppelin_access",
- "openzeppelin_account",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_upgrades"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:560d57a9c3f3ec5a476e82fec8963c93c8df63a4ff9ff134f64ab8383bde3c61"
+checksum = "sha256:1b148d5da1ae90a056b455e8865260423c5491a82777377abfdc68fd8e7d0675"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc505"
+checksum = "sha256:4d5504fef1c5a6d9fee6a3ae392004a4a24b4b3ccb790c5e5217da96beb73e08"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -13,10 +13,9 @@ keywords = ["cartridge", "starknet", "vrf"]
 [dependencies]
 starknet = "^2.12.1"
 stark_vrf = "0.1.1"
-openzeppelin = "2.0.0"
+openzeppelin = "3.0.0"
 
 [dev-dependencies]
-openzeppelin_testing = "6.3.0"
 snforge_std = "0.54.1"
 
 [[target.starknet-contract]]

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -34,6 +34,9 @@ pub use vrf_provider::vrf_provider_component::{
 
 pub mod types;
 pub use types::{PublicKey, Source};
+
+#[cfg(test)]
+pub mod test_helpers;
 // #[cfg(test)]
 // pub mod tests {
 //     pub mod common;

--- a/src/mocks/account_mock.cairo
+++ b/src/mocks/account_mock.cairo
@@ -5,9 +5,9 @@
 mod AccountMock {
     use openzeppelin::account::AccountComponent;
     use openzeppelin::account::extensions::SRC9Component;
+    use openzeppelin::interfaces::upgrades::IUpgradeable;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
     use starknet::ClassHash;
 
     component!(path: AccountComponent, storage: account, event: AccountEvent);

--- a/src/test_helpers.cairo
+++ b/src/test_helpers.cairo
@@ -1,0 +1,27 @@
+use snforge_std::{ContractClass, ContractClassTrait, DeclareResultTrait, declare, get_class_hash};
+use starknet::ContractAddress;
+
+#[generate_trait]
+pub impl AsAddressImpl of AsAddressTrait {
+    const fn as_address(self: felt252) -> ContractAddress {
+        self.try_into().unwrap()
+    }
+}
+
+pub const OWNER: ContractAddress = 'OWNER'.as_address();
+pub const AUTHORIZED: ContractAddress = 'AUTHORIZED'.as_address();
+
+pub fn declare_and_deploy_at(
+    name: ByteArray, contract_address: ContractAddress, calldata: Array<felt252>,
+) {
+    let contract = declare(name).unwrap().contract_class();
+    contract.deploy_at(@calldata, contract_address).unwrap();
+}
+
+pub fn deploy_another_at(
+    existing: ContractAddress, new_address: ContractAddress, calldata: Array<felt252>,
+) {
+    let class_hash = get_class_hash(existing);
+    let contract = ContractClass { class_hash };
+    contract.deploy_at(@calldata, new_address).unwrap();
+}

--- a/src/vrf_account/src9.cairo
+++ b/src/vrf_account/src9.cairo
@@ -11,8 +11,9 @@
 #[starknet::component]
 pub mod SRC9Component {
     use openzeppelin::account::extensions::src9::snip12_utils::OutsideExecutionStructHash;
-    use openzeppelin::account::extensions::src9::{OutsideExecution, interface};
-    use openzeppelin::account::interface::{ISRC6Dispatcher, ISRC6DispatcherTrait};
+    use openzeppelin::interfaces::account::accounts::{ISRC6Dispatcher, ISRC6DispatcherTrait};
+    use openzeppelin::interfaces::account::src9 as interface;
+    use openzeppelin::interfaces::account::src9::OutsideExecution;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin::utils::cryptography::snip12::{OffchainMessageHash, SNIP12Metadata};

--- a/src/vrf_account/tests/common.cairo
+++ b/src/vrf_account/tests/common.cairo
@@ -1,7 +1,6 @@
 use cartridge_vrf::mocks::vrf_consumer_mock::IVrfConsumerMockDispatcher;
+use cartridge_vrf::test_helpers::{AsAddressImpl, declare_and_deploy_at};
 use openzeppelin::utils::serde::SerializedAppend;
-use openzeppelin_testing::constants::AsAddressImpl;
-use openzeppelin_testing::deployment::declare_and_deploy_at;
 use snforge_std::{
     start_cheat_block_timestamp_global, start_cheat_caller_address, start_cheat_chain_id_global,
     stop_cheat_caller_address,

--- a/src/vrf_account/tests/test_dice.cairo
+++ b/src/vrf_account/tests/test_dice.cairo
@@ -1,5 +1,5 @@
-use openzeppelin::account::extensions::src9::OutsideExecution;
-use openzeppelin::account::interface::{ISRC6Dispatcher, ISRC6DispatcherTrait};
+use openzeppelin::interfaces::account::accounts::{ISRC6Dispatcher, ISRC6DispatcherTrait};
+use openzeppelin::interfaces::account::src9::OutsideExecution;
 use snforge_std::{
     CheatSpan, cheat_signature, cheat_transaction_hash, start_cheat_caller_address,
     start_cheat_max_fee,

--- a/src/vrf_account/tests/test_upgrade.cairo
+++ b/src/vrf_account/tests/test_upgrade.cairo
@@ -1,11 +1,10 @@
 use cartridge_vrf::mocks::vrf_consumer_mock::IVrfConsumerMockDispatcher;
-use openzeppelin::upgrades::interface::{
+use cartridge_vrf::test_helpers::{AsAddressImpl, OWNER, declare_and_deploy_at};
+use openzeppelin::interfaces::upgrades::{
     IUpgradeAndCallDispatcher, IUpgradeAndCallDispatcherTrait, IUpgradeableDispatcher,
     IUpgradeableDispatcherTrait,
 };
 use openzeppelin::utils::serde::SerializedAppend;
-use openzeppelin_testing::constants::{AsAddressImpl, OWNER};
-use openzeppelin_testing::deployment::declare_and_deploy_at;
 use snforge_std::{
     CheatSpan, DeclareResultTrait, cheat_caller_address, declare, load, map_entry_address,
     start_cheat_block_timestamp_global, start_cheat_caller_address, start_cheat_chain_id_global,

--- a/src/vrf_account/vrf_account.cairo
+++ b/src/vrf_account/vrf_account.cairo
@@ -3,9 +3,9 @@
 
 #[starknet::contract(account)]
 mod VrfAccount {
+    use openzeppelin::interfaces::upgrades::{IUpgradeAndCall, IUpgradeable};
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::{IUpgradeAndCall, IUpgradeable};
     use starknet::ClassHash;
     use crate::vrf_account::src9::SRC9Component;
     use crate::vrf_account::vrf_account_component::VrfAccountComponent;

--- a/src/vrf_account/vrf_account_component.cairo
+++ b/src/vrf_account/vrf_account_component.cairo
@@ -63,14 +63,13 @@ pub mod VrfAccountComponent {
     use core::hash::{HashStateExTrait, HashStateTrait};
     use core::num::traits::Zero;
     use core::poseidon::{PoseidonTrait, poseidon_hash_span};
-    use openzeppelin::account::interface;
-    use openzeppelin::account::utils::{
-        execute_single_call, is_tx_version_valid, is_valid_stark_signature,
-    };
+    use openzeppelin::account::utils::{is_tx_version_valid, is_valid_stark_signature};
+    use openzeppelin::interfaces::account::accounts as interface;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::introspection::src5::SRC5Component::{
         InternalTrait as SRC5InternalTrait, SRC5Impl,
     };
+    use openzeppelin::utils::execution::execute_single_call;
     use stark_vrf::Proof;
     use starknet::account::Call;
     use starknet::storage::{

--- a/src/vrf_provider/vrf_provider.cairo
+++ b/src/vrf_provider/vrf_provider.cairo
@@ -5,8 +5,8 @@
 pub mod VrfProvider {
     use cartridge_vrf::vrf_provider::vrf_provider_component::VrfProviderComponent;
     use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::interfaces::upgrades::IUpgradeable;
     use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
     use starknet::{ClassHash, ContractAddress};
     use crate::PublicKey;
 

--- a/src/vrf_provider/vrf_provider_upgrader.cairo
+++ b/src/vrf_provider/vrf_provider_upgrader.cairo
@@ -5,8 +5,8 @@
 pub mod VrfProviderUpgrader {
     use cartridge_vrf::vrf_provider::vrf_provider_component::VrfProviderComponent;
     use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::interfaces::upgrades::{IUpgradeAndCall, IUpgradeable};
     use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::{IUpgradeAndCall, IUpgradeable};
     use starknet::{ClassHash, ContractAddress};
     use crate::PublicKey;
 


### PR DESCRIPTION
## Summary

Bumps `openzeppelin` from `2.0.0` to `3.0.0`. OZ 3 splits the umbrella crate into per-domain subcrates (`openzeppelin_access`, `openzeppelin_interfaces`, `openzeppelin_upgrades`, ...) and moves several interface/util surfaces.

Updated 6 module imports for the new paths:
- `openzeppelin::upgrades::interface::*` → `openzeppelin::interfaces::upgrades::*`
- `openzeppelin::account::interface::*` → `openzeppelin::interfaces::account::accounts::*`
- `openzeppelin::account::extensions::src9::interface` → `openzeppelin::interfaces::account::src9`
- `openzeppelin::account::utils::execute_single_call` → `openzeppelin::utils::execution::execute_single_call`

## openzeppelin_testing drop

`openzeppelin_testing` is removed from dev-deps. OZ 3.0.0's transitive `openzeppelin_interfaces 2.1.0` pins `snforge_std ^0.51.2` (as a dev-dep), and no published `openzeppelin_testing` version satisfies both that constraint and OZ 3 APIs — there's a gap in OZ's published matrix.

The only surfaces actually used from `openzeppelin_testing` (`OWNER`, `AUTHORIZED`, `AsAddressImpl`, `declare_and_deploy_at`, `deploy_another_at`) are reimplemented in `src/test_helpers.cairo` using `snforge_std` primitives directly. Once OZ ships an `openzeppelin_testing` that works with OZ 3 + snforge_std 0.51+, this shim can be dropped.

## Downstream impact

Scarb does NOT propagate dev-deps transitively, so downstream consumers building against this commit pick up only the regular `openzeppelin = "3.0.0"` constraint. Verified locally that `nums` (which uses `openzeppelin = "3.0.0"`) builds cleanly against this branch as a path dep.

## Test plan

- [x] `scarb build`
- [x] `scarb fmt --check`
- [x] `snforge test` — 4/4 passing (`test_multicall`, `test_outside_execution__must_consume`, `test_vrf`, `test_upgrade`)
- [x] Downstream path-dep build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)